### PR TITLE
Fix wrong storage key leading to empty labels in shipping center

### DIFF
--- a/src/Controllers/ShippingController.php
+++ b/src/Controllers/ShippingController.php
@@ -719,9 +719,11 @@ class ShippingController extends Controller
             /** @var OrderShippingPackage $result */
             foreach ($results as $result)
             {
-                if ($this->storageRepository->doesObjectExist('ShippingTutorial', $result->packageId.'.pdf'))
+                $labelKey = explode('/', $result->labelPath)[1];
+
+                if ($this->storageRepository->doesObjectExist('ShippingTutorial', $labelKey))
                 {
-                    $storageObject = $this->storageRepository->getObject('ShippingTutorial', $result->packageId.'.pdf');
+                    $storageObject = $this->storageRepository->getObject('ShippingTutorial', $labelKey);
                     $labels[] = $storageObject->body;
                 }
             }


### PR DESCRIPTION
In the example the function getLabels doesn't return the saved PDF label files when trying to display them in the shipping center.

Adjust the code according to [this](https://forum.plentymarkets.com/t/shipping-plugin/526380/13) thread in forum and viewing the labels works.